### PR TITLE
Add basic auth to API mapping

### DIFF
--- a/request.js
+++ b/request.js
@@ -39,6 +39,11 @@ module.exports.clusterOptions = (kubeconfig, method, path) => {
 		});
 	}
 
+	const user = ctx.user;
+	if (user.user.username && user.user.password) {
+		baseOptions.auth = `${user.user.username}:${user.user.password}`;
+	}
+
 	return baseOptions;
 };
 


### PR DESCRIPTION
If the current context user is a username/password user,
use that as the basic auth for the requests.

This seems to not be necessary otherwise.

fixes #1 